### PR TITLE
fix: polish error handling across all search flows

### DIFF
--- a/src/components/ErrorToast.tsx
+++ b/src/components/ErrorToast.tsx
@@ -28,7 +28,7 @@ export function ErrorToast({ message, onDismiss }: Props) {
       role="alert"
       aria-live="assertive"
       className={[
-        "fixed top-[68px] left-1/2 -translate-x-1/2 z-[1500] max-w-[90vw]",
+        "fixed top-[68px] left-1/2 -translate-x-1/2 z-[1500] min-w-[240px] max-w-[90vw]",
         "bg-[var(--color-error)] text-[var(--color-on-error)] text-sm font-medium px-4 py-3 rounded-xl elevation-2",
         "flex items-center gap-2 transition-all duration-300",
         visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -49,7 +49,7 @@ async function geocode(query: string): Promise<{ lat: number; lng: number } | nu
 
   const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(query)}`;
   const res = await fetch(url, { headers: { "Accept-Language": "en" } });
-  if (!res.ok) return null;
+  if (!res.ok) throw new Error(`Geocode HTTP ${res.status}`);
   const results = await res.json();
   if (!results[0]) return null;
   const result = { lat: Number(results[0].lat), lng: Number(results[0].lon) };
@@ -72,7 +72,7 @@ export const Toolbar = memo(function Toolbar({ onLocationFound, onRecenter, mapR
   const { openShare } = useShare();
   const [query, setQuery] = useState("");
   const [isGeocoding, setIsGeocoding] = useState(false);
-  const [locationNotFound, setLocationNotFound] = useState(false);
+  const [geocodeError, setGeocodeError] = useState<"not-found" | "network" | null>(null);
   const [layerPickerOpen, setLayerPickerOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -92,7 +92,7 @@ export const Toolbar = memo(function Toolbar({ onLocationFound, onRecenter, mapR
       if (center) onLocationFound({ lat: center.lat, lng: center.lng }, 16);
       return;
     }
-    setLocationNotFound(false);
+    setGeocodeError(null);
     setIsGeocoding(true);
     try {
       const pos = await geocode(q);
@@ -100,23 +100,23 @@ export const Toolbar = memo(function Toolbar({ onLocationFound, onRecenter, mapR
         onLocationFound(pos);
         inputRef.current?.blur();
       } else {
-        setLocationNotFound(true);
+        setGeocodeError("not-found");
       }
     } catch {
-      setLocationNotFound(true);
+      setGeocodeError("network");
     } finally {
       setIsGeocoding(false);
     }
   };
 
-  const bannerHeight = locationNotFound || locationDenied ? 32 : 0;
+  const bannerHeight = geocodeError !== null || locationDenied ? 32 : 0;
   const fabTop = 12 + 56 + bannerHeight + 8;
 
   return (
     <>
       <header
         className="fixed top-3 left-3 right-3 z-[1000] bg-[var(--color-surface-glass)] backdrop-blur-sm elevation-2 rounded-2xl overflow-hidden"
-        style={{ height: locationDenied || locationNotFound ? "auto" : 56 }}
+        style={{ height: locationDenied || geocodeError !== null ? "auto" : 56 }}
       >
         <div className="flex items-center px-3 gap-2" style={{ height: 56 }}>
           {/* Hamburger */}
@@ -151,7 +151,7 @@ export const Toolbar = memo(function Toolbar({ onLocationFound, onRecenter, mapR
           <form onSubmit={handleSearch} className="flex-1 flex items-center">
             <div className={[
               "flex items-center w-full rounded-full border transition-colors",
-              locationNotFound
+              geocodeError !== null
                 ? "border-red-400 bg-red-50 dark:bg-red-950/30 dark:border-red-800"
                 : "border-[var(--color-border-search)] bg-[var(--color-surface-search)] focus-within:border-[var(--color-primary)] focus-within:bg-[var(--color-surface)]",
             ].join(" ")}>
@@ -159,7 +159,7 @@ export const Toolbar = memo(function Toolbar({ onLocationFound, onRecenter, mapR
                 ref={inputRef}
                 type="search"
                 value={query}
-                onChange={(e) => { setQuery(e.target.value); setLocationNotFound(false); }}
+                onChange={(e) => { setQuery(e.target.value); setGeocodeError(null); }}
                 placeholder="Search location…"
                 aria-label="Search location"
                 className="flex-1 bg-transparent text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 px-4 py-2 min-h-[44px] outline-none min-w-0"
@@ -187,13 +187,19 @@ export const Toolbar = memo(function Toolbar({ onLocationFound, onRecenter, mapR
 
         </div>
 
-        {locationNotFound && (
+        {geocodeError === "not-found" && (
           <div className="bg-red-50 dark:bg-red-950/40 border-t border-red-200 dark:border-red-900 px-4 py-1.5 text-xs text-red-700 dark:text-red-400 text-center">
             Location not found — try a different search term.
           </div>
         )}
 
-        {locationDenied && !locationNotFound && (
+        {geocodeError === "network" && (
+          <div className="bg-red-50 dark:bg-red-950/40 border-t border-red-200 dark:border-red-900 px-4 py-1.5 text-xs text-red-700 dark:text-red-400 text-center">
+            Search failed — check your connection and try again.
+          </div>
+        )}
+
+        {locationDenied && geocodeError === null && (
           <div className="bg-amber-50 dark:bg-amber-950/30 border-t border-amber-200 dark:border-amber-900 px-4 py-1.5 text-xs text-amber-800 dark:text-amber-400 text-center">
             Location access denied — search above or enable location to find stations near you.
           </div>

--- a/src/hooks/useStationQuery.ts
+++ b/src/hooks/useStationQuery.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { OverpassNode } from "../types/overpass";
 import { fetchStations } from "../lib/overpass";
 import { ENV } from "../lib/env";
@@ -11,6 +11,11 @@ export type StationQueryState =
   | { status: "none" }
   | { status: "error"; message: string };
 
+export type StationQueryResult = StationQueryState & {
+  /** Increment to re-run the fetch at the same coordinates (retry after error). */
+  retry: () => void;
+};
+
 function errorMessage(err: Error): string {
   if (err.message.includes("429"))
     return "Too many requests — please wait a moment and try again.";
@@ -20,6 +25,10 @@ function errorMessage(err: Error): string {
     err.message.includes("503")
   )
     return "The map server is busy — please try again in a moment.";
+  if (err.message.includes("server timeout"))
+    return "Search timed out — try a smaller area or try again.";
+  if (err instanceof TypeError)
+    return "Network error — check your connection and try again.";
   return err.message || "Failed to load stations. Check your connection.";
 }
 
@@ -37,12 +46,16 @@ export function useStationQuery(
   lat: number | null,
   lng: number | null,
   fetchRadiusKm: number = FETCH_RADIUS_KM,
-): StationQueryState {
+): StationQueryResult {
   const [state, setState] = useState<StationQueryState>(() => {
     const cached = readCache();
     if (!cached) return { status: "idle" };
     return { status: "success", stations: cached.stations };
   });
+
+  // Incrementing retryTick re-runs the fetch even at the same coordinates.
+  const [retryTick, setRetryTick] = useState(0);
+  const retry = useCallback(() => setRetryTick((t) => t + 1), []);
 
   const abortRef = useRef<AbortController | null>(null);
 
@@ -75,7 +88,7 @@ export function useStationQuery(
     // Cache hit — serve immediately
     const cached = readCache();
     if (cached && isCovered(lat, lng, cached, fetchRadiusKm)) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- correct pattern: latch cached data synchronously
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- early return: cache hit avoids fetch
       setState({ status: "success", stations: cached.stations });
       return;
     }
@@ -101,11 +114,11 @@ export function useStationQuery(
         if (err.name === "AbortError") return;
         setState({ status: "error", message: errorMessage(err) });
       });
-  }, [lat, lng, fetchRadiusKm]);
+  }, [lat, lng, fetchRadiusKm, retryTick]);
 
   useEffect(() => {
     return () => { abortRef.current?.abort(); };
   }, []);
 
-  return state;
+  return { ...state, retry };
 }

--- a/src/lib/overpass.ts
+++ b/src/lib/overpass.ts
@@ -30,10 +30,20 @@ async function tryEndpoint(
   }
 
   const json: OverpassResponse = await res.json();
+
+  // Overpass returns HTTP 200 with a `remark` field on server-side timeouts
+  if (json.remark && /timeout|runtime error/i.test(json.remark)) {
+    throw new Error("Overpass API error: server timeout");
+  }
+
   return json.elements;
 }
 
 function isRetryable(err: Error): boolean {
+  // Network-level failures (offline, DNS, CORS) throw TypeError per Fetch spec
+  if (err instanceof TypeError) return true;
+  // Server-side Overpass timeout — worth trying another mirror
+  if (err.message.includes("server timeout")) return true;
   return RETRYABLE_STATUSES.has(
     Number(err.message.match(/HTTP (\d+)/)?.[1] ?? 0)
   );

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -127,6 +127,9 @@ export default function MapPage() {
   const [activeLayer, setActiveLayer] = useState<LayerId>("cycling");
   const [errorDismissed, setErrorDismissed] = useState(false);
   const [selectedStationId, setSelectedStationId] = useState<number | null>(null);
+
+  // Track last successful selectedDist so we can revert on error (Fix 6)
+  const lastSuccessDistRef = useRef(selectedDist);
   const [listExpanded, setListExpanded] = useState(false);
   const [initialFlyComplete, setInitialFlyComplete] = useState(false);
 
@@ -160,6 +163,7 @@ export default function MapPage() {
     givenLocation?.lng ?? null,
     fetchRadiusKm,
   );
+  const { retry } = query;
 
   // Preserve previous stations during loading so the list doesn't flash empty.
   // Google/Apple Maps pattern: old results stay visible with a pulsing header,
@@ -171,7 +175,7 @@ export default function MapPage() {
     setStaleStations(queryStations);
   }
   const allStations = useMemo(
-    () => queryStations ?? (query.status === "loading" ? staleStations : []),
+    () => queryStations ?? (query.status === "loading" || query.status === "error" ? staleStations : []),
     [queryStations, query.status, staleStations],
   );
 
@@ -272,6 +276,14 @@ export default function MapPage() {
 
   const handleInitialFlyComplete = useCallback(() => setInitialFlyComplete(true), []);
 
+  // Fix 8: Safety net — if MapView chunk fails to load or flyTo never fires,
+  // force the overlay away after 15 seconds to avoid a permanent spinner.
+  useEffect(() => {
+    if (initialFlyComplete) return;
+    const timer = setTimeout(() => setInitialFlyComplete(true), 15_000);
+    return () => clearTimeout(timer);
+  }, [initialFlyComplete]);
+
   const handleMapInteraction = useCallback(() => setListExpanded(false), []);
 
   // Distance pill selected manually by the user
@@ -319,6 +331,23 @@ export default function MapPage() {
     }
   }, [query.status, givenLocation]);
 
+  // Fix 5: Restore "Search this area" FAB after error so user can retry
+  useEffect(() => {
+    if (query.status === "error") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: surface retry affordance when fetch fails
+      setMapMovedSinceSearch(true);
+    }
+  }, [query.status]);
+
+  // Fix 6: Track last successful distance; revert pill on error
+  useEffect(() => {
+    if (query.status === "success") {
+      lastSuccessDistRef.current = selectedDist;
+    } else if (query.status === "error" && selectedDist !== lastSuccessDistRef.current) {
+      setSelectedDist(lastSuccessDistRef.current);
+    }
+  }, [query.status, selectedDist]);
+
   const handleSearchHere = useCallback(() => {
     if (!mapCenter) return;
     setMapMovedSinceSearch(false);
@@ -347,7 +376,9 @@ export default function MapPage() {
       userPosition !== null &&
       haversineDistanceMiles(mapCenter.lat, mapCenter.lng, userPosition.lat, userPosition.lng) < 1;
     setSearchedLocation(nearUser ? null : mapCenter);
-  }, [mapCenter, userPosition, unit]);
+    // Ensure the fetch re-runs even at the same coordinates (same-location retry after error)
+    retry();
+  }, [mapCenter, userPosition, unit, retry]);
 
   // Filter centre: explicit location (geo/search) → map centre → null
   const filterCenter = givenLocation ?? mapCenter;

--- a/src/types/overpass.ts
+++ b/src/types/overpass.ts
@@ -20,4 +20,6 @@ export interface OverpassNode {
 export interface OverpassResponse {
   version: number;
   elements: OverpassNode[];
+  /** Present when the server encounters a runtime error or timeout. */
+  remark?: string;
 }


### PR DESCRIPTION
## Summary
- **Network retry**: `TypeError` (offline/DNS) errors now retry across all 3 Overpass mirrors instead of failing immediately
- **Server timeout detection**: Overpass server-side timeouts (HTTP 200 with `remark` field) are detected, retried across mirrors, and produce a distinct user message
- **Retry via FAB**: "Search this area" button reappears after any Overpass error, serving as the retry affordance — no new UI elements added
- **Stale data preserved**: Previous stations remain visible during error state (markers + list stay on screen while toast is shown)
- **Pill revert on error**: Distance pill reverts to last successful value if a wider search fails
- **Distinct geocode errors**: Toolbar banner now differentiates "Location not found" from "Search failed — check your connection"
- **ErrorToast sizing**: `min-w-[240px]` ensures the toast always covers the FAB pill for a consistent flow (error → fade → retry revealed)
- **LoadingOverlay safety net**: 15-second timeout prevents permanent spinner if MapView chunk fails to load

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Docs / content
- [ ] Chore (deps, config, CI)

## Test plan
- [ ] **Network offline → Overpass**: DevTools Offline → triggers retry across all 3 mirrors → toast "Network error — check your connection" → "Search this area" FAB reappears → go online → tap FAB → stations load
- [ ] **Overpass 429**: toast "Too many requests…" → FAB reappears → tap to retry
- [ ] **Server timeout**: large radius search → toast "Search timed out — try a smaller area" → FAB reappears
- [ ] **Geocode network error**: offline → type location → red banner "Search failed — check your connection"
- [ ] **Geocode not found**: gibberish query → red banner "Location not found — try a different search term"
- [ ] **Pill revert**: select 250 mi → error → pill reverts to previous value, FAB appears
- [ ] **Stale stations on error**: have stations → trigger error → stations still visible + toast
- [ ] **Overlay timeout**: block MapView chunk → overlay clears after 15s
- [ ] **Dark mode**: all error states render correctly in both themes

## Checklist
- [x] `npm run build` passes locally
- [x] Dark mode and light mode tested
- [x] Mobile viewport tested (or change is not UI-related)
- [x] No new a11y contrast issues introduced
- [x] ARIA semantics preserved (landmarks, control names, live regions)
- [ ] Dialog keyboard behavior verified (focus trap, Escape close, focus return)
- [x] Axe scan run on touched route(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)