### PR TITLE
chore(build): clear recurring build and console hygiene noise

### DIFF
--- a/api/create-checkout-session.test.ts
+++ b/api/create-checkout-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import handler from "./create-checkout-session";
+import handler from "./create-checkout-session.js";
 
 // Mock the Stripe SDK that is dynamically imported inside the handler.
 // Must use a class (not an arrow function) because the handler calls `new Stripe(...)`.

--- a/api/geo.test.ts
+++ b/api/geo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import handler from "./geo";
+import handler from "./geo.js";
 
 function makeRequest(headers: Record<string, string> = {}): Request {
   return new Request("http://localhost/api/geo", { headers });

--- a/api/report-bug.test.ts
+++ b/api/report-bug.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import handler from "./report-bug";
+import handler from "./report-bug.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/lib/overpass.test.ts
+++ b/src/lib/overpass.test.ts
@@ -53,12 +53,11 @@ describe("fetchStations", () => {
     const station = { type: "node", id: 3, lat: 51.5, lon: -0.1, tags: {} };
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(errorResponse(502))
-      .mockResolvedValueOnce(errorResponse(503))
       .mockResolvedValueOnce(okResponse([station]));
 
     const result = await fetchStations(51.5, -0.1, 40, PRIMARY);
     expect(result).toHaveLength(1);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 
   it("retries on TypeError (network failure)", async () => {
@@ -99,24 +98,21 @@ describe("fetchStations", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("throws after all 3 mirrors fail", async () => {
+  it("throws after all mirrors fail", async () => {
     vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(errorResponse(429))
       .mockResolvedValueOnce(errorResponse(429))
       .mockResolvedValueOnce(errorResponse(429));
 
     await expect(fetchStations(51.5, -0.1, 40, PRIMARY)).rejects.toThrow("HTTP 429");
-    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 
   it("detects server timeout with various remark messages", async () => {
-    // "runtime error" variant
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(remarkResponse("runtime error: Query timed out in \"query\" at line 1"))
-      .mockResolvedValueOnce(remarkResponse("Timeout occurred"))
-      .mockResolvedValueOnce(remarkResponse("timeout reached"));
+      .mockResolvedValueOnce(remarkResponse("Timeout occurred"));
 
     await expect(fetchStations(51.5, -0.1, 40, PRIMARY)).rejects.toThrow("server timeout");
-    expect(globalThis.fetch).toHaveBeenCalledTimes(3); // tried all mirrors
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2); // tried all mirrors
   });
 });

--- a/src/lib/overpass.ts
+++ b/src/lib/overpass.ts
@@ -1,9 +1,16 @@
 import type { OverpassNode, OverpassResponse } from "../types/overpass";
 
-/** Public Overpass mirrors tried in order when the primary endpoint fails. */
+/**
+ * Public Overpass mirrors tried in order when the primary endpoint fails.
+ *
+ * Browser fallbacks must serve `Access-Control-Allow-Origin: *`; mirrors that
+ * don't (e.g. overpass.openstreetmap.ru) fail every request on CORS regardless
+ * of server health and only add noise to the console. `overpass.kumi.systems`
+ * is currently the only CORS-enabled mirror we trust enough to keep here — add
+ * new entries only after verifying CORS from a browser origin.
+ */
 export const FALLBACK_ENDPOINTS = [
   "https://overpass.kumi.systems/api/interpreter",
-  "https://overpass.openstreetmap.ru/api/interpreter",
 ];
 
 /** HTTP status codes that indicate server overload — worth retrying elsewhere. */

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -73,7 +73,6 @@ describe("initSentry", () => {
       expect.arrayContaining([
         "overpass-api.de",
         "overpass.kumi.systems",
-        "overpass.openstreetmap.ru",
         "nominatim.openstreetmap.org",
       ])
     );
@@ -102,7 +101,6 @@ describe("initSentry", () => {
     expect(targets).toEqual(
       expect.arrayContaining([
         "overpass.kumi.systems",
-        "overpass.openstreetmap.ru",
         "nominatim.openstreetmap.org",
       ])
     );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,12 @@ export default defineConfig(({ mode }) => {
         manifest: false,
         workbox: {
           globPatterns: ["**/*.{js,css,html,png,svg,ico}"],
+          // Workbox emits sw.js.map and workbox-*.js.map AFTER the Sentry
+          // plugin's filesToDeleteAfterUpload cleanup runs, so those maps
+          // would otherwise ship to the CDN as publicly fetchable assets.
+          // We don't upload the service-worker bundle to Sentry, so we just
+          // suppress the maps here.
+          sourcemap: false,
           runtimeCaching: [
             {
               // CARTO tiles (Voyager, Positron, Dark Matter, labels-only)


### PR DESCRIPTION
## Summary

Three unrelated but always-visible hygiene issues, bundled into one focused PR so they stop reappearing in every review.

1. **Dropped \`overpass.openstreetmap.ru\` from the Overpass fallback list.** The mirror doesn't send \`Access-Control-Allow-Origin\`, so browsers reject every request on CORS regardless of server health. Combined with intermittent primary outages, users saw a red console on every page load. \`overpass.kumi.systems\` remains as the sole CORS-enabled fallback; \`sentry.ts\` derives trace-propagation targets from the same list, so those update automatically (the hard-coded \`arrayContaining\` assertion in \`sentry.test.ts\` was also adjusted). I could not verify CORS on alternative mirrors (\`overpass.private.coffee\`, \`maps.mail.ru\`, \`overpass.osm.jp\`) from the environment I was working in — flagged below as a follow-up.
2. **Added \`.js\` extensions to api test imports** (\`api/create-checkout-session.test.ts\`, \`api/geo.test.ts\`, \`api/report-bug.test.ts\`). Vercel compiles \`api/\` under \`moduleResolution: nodenext\`, which requires explicit \`.js\` extensions on ESM relative imports. The missing extensions logged three TS2835 errors on every \`vercel build\` without failing the build. Vitest's bundler resolution maps \`.js\` → \`.ts\` transparently, so tests still run locally.
3. **Disabled Workbox sourcemaps** (\`workbox.sourcemap: false\` in \`vite.config.ts\`). Workbox emits \`sw.js.map\` and \`workbox-*.js.map\` *after* the Sentry plugin's \`filesToDeleteAfterUpload\` cleanup runs, so those maps previously shipped to the CDN as publicly fetchable assets — defeating the rationale behind e39c318. We don't upload the service-worker bundle to Sentry, so suppressing map generation at the source is cleaner than a post-build \`rm\`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Docs / content
- [x] Chore (deps, config, CI)

## Test plan

- \`npm run lint\` clean.
- \`npm run build\` clean; \`find dist -name "*.map"\` returns nothing.
- \`npm test -- --run src/lib/ api/\` → 102 passed.
- \`src/lib/overpass.test.ts\` updated to reflect the now-2-mirror chain (primary + kumi) and continues to exercise the retry path.
- Pre-existing \`src/context/ShareProvider.test.tsx\` failures are unrelated to this PR (verified by running them against the pre-change tree); not in scope.

## Follow-ups (not in this PR)

- **Verify at least one additional CORS-enabled Overpass mirror** from a real browser origin and add it back to \`FALLBACK_ENDPOINTS\`. Candidates: \`overpass.private.coffee\`, \`maps.mail.ru\`, \`overpass.osm.jp\`. Running with only one fallback means a single kumi.systems outage takes the app down.
- **Orphan chunk in Sentry upload log** (\`~/4407f3bb-…-12.js\` → \`could not determine a source map reference\`). 13/14 chunks upload fine; one doesn't. May need explicit \`sourcemaps.assets\` config. Needs a Sentry-authenticated build to diagnose.
- **\`ShareProvider\` test suite is red on \`main\`.** Seven failures; unrelated to this change. Worth a separate triage.

## Checklist

### Build & Lint
- [x] \`npm run lint\` passes with no errors or warnings
- [x] \`npm run build\` passes locally

### Accessibility (a11y)
- [ ] No new contrast issues (WCAG AA: 4.5:1 text, 3:1 large text)
- [ ] All interactive elements have accessible names (\`aria-label\`, \`aria-labelledby\`, or visible label)
- [ ] ARIA landmarks, roles, and live regions preserved
- [ ] No \`aria-*\` attributes referencing non-existent IDs
- [ ] Axe scan run on touched route(s)

### Dialog & Keyboard
- [ ] Dialog/modal focus trap, Escape-to-close, and focus-return-to-trigger verified (if applicable)

### Dark Mode
- [ ] No hardcoded colors without \`dark:\` variants
- [ ] Dark mode and light mode tested

### i18n Readiness
- [ ] No new hardcoded user-facing strings in TSX
- [ ] No string concatenation that would break translation (use template placeholders)

### MD3 Compliance
- [ ] Touch targets meet 48x48 dp minimum on interactive elements
- [ ] Colors use project token structure (primary/secondary/tertiary/error), not ad-hoc hex values
- [ ] State layers (hover, focus, pressed) present on interactive surfaces

### Data Flow
- [ ] \`useCallback\`/\`useMemo\`/\`React.memo\` dependency arrays are correct (if applicable)
- [ ] Context value objects are wrapped in \`useMemo\` (if providers were modified)
- [ ] No new prop-drilling that bypasses existing Context hooks
- [ ] Cache invalidation logic intact (if \`stationCache.ts\` or \`useStationQuery.ts\` was touched)

### Responsive
- [ ] Mobile viewport tested at 375px width (or change is not UI-related)
- [ ] No horizontal overflow introduced

### Docs
- [ ] README or docs updated (if user-facing feature)
- [ ] \`.env.example\` updated (if new env vars added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)