### PR TITLE
chore(deps): remove unused @stripe/stripe-js client SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@sentry/react": "^10.49.0",
-        "@stripe/stripe-js": "^9.0.1",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "i18next": "^26.0.3",
@@ -53,6 +52,9 @@
         "vite": "^8.0.1",
         "vite-plugin-pwa": "^1.2.0",
         "vitest": "^4.1.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3382,15 +3384,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@stripe/stripe-js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.0.1.tgz",
-      "integrity": "sha512-un0URSosrW7wNr7xZ5iI2mC9mdeXZ3KERoVlA2RdmeLXYxHUPXq0yHzir2n/MtyXXEdSaELtz4WXGS6dzPEeKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.16"
-      }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@sentry/react": "^10.49.0",
-    "@stripe/stripe-js": "^9.0.1",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "i18next": "^26.0.3",


### PR DESCRIPTION
## Summary

- Removes `@stripe/stripe-js` from `dependencies` — it was declared but imported nowhere under `src/`.
- The donate flow in [`src/pages/DonatePage.tsx`](src/pages/DonatePage.tsx) uses the server-side `stripe` package via `/api/create-checkout-session` and browser-redirects to the returned Checkout URL. The client SDK is not part of that path.
- If a future feature needs Stripe Elements (embedded card form, saved payment methods, Apple/Google Pay Element), re-add the dep then.

Closes #34. Makes [#31](https://github.com/thomHayner/bicycle-repair-stations/pull/31) obsolete — that Dependabot bump PR should be closed after this merges.

## Type of change

- [ ] feat (new user-visible feature)
- [ ] fix (user-visible bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance improvement)
- [x] chore (deps / tooling / housekeeping)
- [ ] docs (docs-only)
- [ ] test (test-only)
- [ ] ci (CI config)

## Test plan

- [x] `npm run lint` — pass
- [x] `npm run build` — pass (tsc -b + vite build)
- [x] `npm test` — 217 passed / 22 files
- [ ] Manual: click Donate → redirected to Stripe Checkout → cancel returns to `/donate` (preview deploy recommended)

## Checklist

### Build & Lint

- [ ] Type checks pass (`tsc -b`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Production build succeeds (`npm run build`)

### Accessibility

- [ ] N/A — dependency removal, no UI change

### Dialog & Keyboard

- [ ] N/A

### Dark Mode

- [ ] N/A

### i18n Readiness

- [ ] N/A

### MD3 Compliance

- [ ] N/A

### Data Flow

- [ ] N/A

### Responsive

- [ ] N/A — but verify donate redirect still works on mobile viewport

### Docs

- [ ] No doc changes needed (CLAUDE.md and CONTRIBUTING.md don't mention this dep)
