### PR TITLE
chore(ci): branch hygiene — dev as default base, fix pr-title workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   # ─── Type-check, lint, and build ────────────────────────────────────────────

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,8 +31,8 @@ jobs:
             revert
           # Subject must not start with an uppercase letter or end with a period —
           # matches commitlint `subject-case` and `subject-full-stop` rules.
-          # Quoted because the unquoted form contains `: ` which YAML would
-          # parse as a mapping separator, breaking the workflow file.
+          # Quoted for consistency with `headerPattern` and to keep the regex
+          # easy to read/debug as a YAML string.
           subjectPattern: "^(?![A-Z])(?!.*\\.$).+$"
           subjectPatternError: |
             The PR title subject must start with a lowercase letter and must not end with a period.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,7 +31,9 @@ jobs:
             revert
           # Subject must not start with an uppercase letter or end with a period —
           # matches commitlint `subject-case` and `subject-full-stop` rules.
-          subjectPattern: ^(?![A-Z])(?!.*\.$).+$
+          # Quoted because the unquoted form contains `: ` which YAML would
+          # parse as a mapping separator, breaking the workflow file.
+          subjectPattern: "^(?![A-Z])(?!.*\\.$).+$"
           subjectPatternError: |
             The PR title subject must start with a lowercase letter and must not end with a period.
             Conventional Commits format: <type>(<scope>): <subject>
@@ -43,4 +45,6 @@ jobs:
           # Making `!` a capturing group shifts `subject` onto the `!` match
           # and fails otherwise-valid breaking-change titles. (Caught by
           # Copilot on PR #27.)
-          headerPattern: ^(\w+)(?:\(([^)]+)\))?(?:!)?: (.+)$
+          # Quoted because the unquoted form contains `: ` which YAML would
+          # parse as a mapping separator, breaking the workflow file.
+          headerPattern: "^(\\w+)(?:\\(([^)]+)\\))?(?:!)?: (.+)$"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,17 @@ npm run test:e2e     # playwright test
 npm run test:e2e:ui  # playwright test --ui
 ```
 
+## Branching & base-branch defaults
+
+`dev` is the integration branch. When the user asks for a new branch or a new PR without specifying a base:
+
+- **Branch from `dev`.** `git checkout dev && git pull && git checkout -b <new-branch>` — not from `main`, not from whatever branch happens to be checked out.
+- **Target `dev` for PRs.** Pass `--base dev` to `gh pr create`. Only target `main` when the user explicitly says so (e.g. "PR into main", "release PR", "promote to main").
+- `main` is reserved for release promotion from `dev`; treat it as protected.
+- `dev` is branch-protected on GitHub (no deletions, no force-push, admin-enforced). Do not attempt to delete or force-push it.
+
+This overrides the generic "Main branch (you will usually use this for PRs): main" hint that may appear in the session's `gitStatus` preamble.
+
 ## Commit & PR conventions
 
 All commits **and PR titles** must follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). The full spec, allowed types, and recommended scopes live in [`CONTRIBUTING.md#commit-messages`](CONTRIBUTING.md#commit-messages) — read it before authoring a commit or PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,7 @@ npm run test:e2e:ui  # playwright test --ui
 
 - **Branch from `dev`.** `git checkout dev && git pull && git checkout -b <new-branch>` — not from `main`, not from whatever branch happens to be checked out.
 - **Target `dev` for PRs.** Pass `--base dev` to `gh pr create`. Only target `main` when the user explicitly says so (e.g. "PR into main", "release PR", "promote to main").
-- `main` is reserved for release promotion from `dev`; treat it as protected.
-- `dev` is branch-protected on GitHub (no deletions, no force-push, admin-enforced). Do not attempt to delete or force-push it.
+- Treat both `main` and `dev` as protected: do not delete or force-push them, and do not attempt to bypass branch rules. `main` is reserved for release promotion from `dev`. If an exception is ever needed, coordinate with a repo admin — don't assume GitHub will block you, since protection settings live in repo configuration and can drift.
 
 This overrides the generic "Main branch (you will usually use this for PRs): main" hint that may appear in the session's `gitStatus` preamble.
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits: <type>(<scope>): <subject>
We squash-merge, so the title becomes the single commit on \`main\`.
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
Full spec & recommended scopes: CONTRIBUTING.md#commit-messages
-->

## Summary

Three small changes to make \`dev\` the canonical integration branch and to un-break the PR-title check:

- **\`fix(ci): quote pr-title regex patterns\`** — \`pr-title.yml\` contained unquoted regex scalars with \`: \` inside them, which YAML parses as a mapping separator. Every push was producing a failed run surfaced as \`.github/workflows/pr-title.yml\` because GitHub could not read the workflow's \`name:\` field. Double-quoting both patterns and escaping the backslashes restores the workflow. Regex semantics are unchanged.
- **\`ci: run build on dev branch\`** — \`ci.yml\` only triggered on \`main\`; adding \`dev\` to both \`push\` and \`pull_request\` is a prerequisite for requiring \`Lint & Build\` as a status check on \`dev\`.
- **\`docs: default to dev as base branch for new work\`** — adds a \`Branching & base-branch defaults\` section to \`CLAUDE.md\` so Claude sessions and spawned agents consistently branch off \`dev\` and target \`dev\` for PRs unless told otherwise.

Follow-up (separate PR): tighten branch protection on \`main\` (\`enforce_admins: true\`, add \`Lint commit messages\` to required checks) and add equivalent protection on \`dev\` now that CI runs there.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Docs / content
- [ ] Chore (deps, config, CI)

## Test plan

- [ ] Confirm this PR's \`PR title\` check runs and passes (validates the YAML fix).
- [ ] Confirm this PR's \`Lint & Build\` check runs against the dev base (validates the trigger change).
- [ ] Confirm \`Commitlint\` runs (unchanged, but should still pass).

## Checklist

### Build & Lint
- [ ] \`npm run lint\` passes with no errors or warnings
- [ ] \`npm run build\` passes locally

### Accessibility (a11y)
- [ ] No new contrast issues (WCAG AA: 4.5:1 text, 3:1 large text)
- [ ] All interactive elements have accessible names (\`aria-label\`, \`aria-labelledby\`, or visible label)
- [ ] ARIA landmarks, roles, and live regions preserved
- [ ] No \`aria-*\` attributes referencing non-existent IDs
- [ ] Axe scan run on touched route(s)

### Dialog & Keyboard
- [ ] Dialog/modal focus trap, Escape-to-close, and focus-return-to-trigger verified (if applicable)

### Dark Mode
- [ ] No hardcoded colors without \`dark:\` variants
- [ ] Dark mode and light mode tested

### i18n Readiness
- [ ] No new hardcoded user-facing strings in TSX
- [ ] No string concatenation that would break translation (use template placeholders)

### MD3 Compliance
- [ ] Touch targets meet 48x48 dp minimum on interactive elements
- [ ] Colors use project token structure (primary/secondary/tertiary/error), not ad-hoc hex values
- [ ] State layers (hover, focus, pressed) present on interactive surfaces

### Data Flow
- [ ] \`useCallback\`/\`useMemo\`/\`React.memo\` dependency arrays are correct (if applicable)
- [ ] Context value objects are wrapped in \`useMemo\` (if providers were modified)
- [ ] No new prop-drilling that bypasses existing Context hooks
- [ ] Cache invalidation logic intact (if \`stationCache.ts\` or \`useStationQuery.ts\` was touched)

### Responsive
- [ ] Mobile viewport tested at 375px width (or change is not UI-related)
- [ ] No horizontal overflow introduced

### Docs
- [ ] README or docs updated (if user-facing feature)
- [ ] \`.env.example\` updated (if new env vars added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)