### PR TITLE
chore(ci): stop dev/main drift at the source

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    # Target the integration branch, not main. main is production-only and should
+    # only change via release PRs from dev.
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -27,6 +30,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     commit-message:

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -3,6 +3,16 @@
 // PR titles are validated separately by .github/workflows/pr-title.yml.
 export default {
   extends: ['@commitlint/config-conventional'],
+  // Skip commits we don't author directly:
+  // - "Merge …" = git-generated merge commits
+  // - squash-merge bodies that aggregate multiple commits as bulleted
+  //   conventional-commit headers (GitHub's default squash body). These
+  //   routinely fail body/subject rules through no fault of the author
+  //   and caused the PR #37 dev→main release to need an admin override.
+  ignores: [
+    (msg) => msg.startsWith('Merge '),
+    (msg) => /^\* (feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: /m.test(msg),
+  ],
   rules: {
     // Closed allowlist — undocumented types are rejected.
     'type-enum': [


### PR DESCRIPTION
## Summary
Three changes that together eliminate the sync-PR cycle that made the last release (PR #37) need four reconciliation merges and an admin override.

- **`.github/dependabot.yml`** — `target-branch: dev` on both ecosystems. Dependency PRs now land on `dev`; `main` only changes via release PRs.
- **`commitlint.config.mjs`** — `ignores` for plain merge commits and for squash-merge bodies with aggregated bulleted conventional-commit headers (what tripped PR #37).
- **Branch protection (API, not in-repo)** — `required_status_checks.strict: false` on `dev`, retained on `main`. Already applied. Recorded here so the config state is visible alongside the code changes.

After this lands the workflow is:
- All work branches from `dev`, PRs into `dev`.
- Dependabot PRs into `dev`.
- Release = one PR from `dev` into `main` whenever you want to ship.

## Type of change
- [x] Chore (deps, config, CI)

## Test plan
- [ ] Dependabot config validates (`gh api /repos/{owner}/{repo}/dependabot/alerts` still responds; real test is the next scheduled run)
- [x] `commitlint.config.mjs` parses; this commit's message passed the local hook
- [x] `dev` branch protection confirmed `strict: false`, `main` confirmed `strict: true`